### PR TITLE
Update override page to use pre-populated ComboBoxes (and other small changed)

### DIFF
--- a/wv2util/AppOverride.cs
+++ b/wv2util/AppOverride.cs
@@ -173,7 +173,14 @@ namespace wv2util
             foreach (string valueName in valueNames)
             {
                 AppOverrideEntry entry = GetOrCreateEntry(appNameToEntry, collection, valueName);
-                entry.ReverseSearchOrder = (1 == (int)regKey.GetValue(valueName));
+                try
+                {
+                    entry.ReverseSearchOrder = (1 == (int)regKey.GetValue(valueName));
+                }
+                catch (InvalidCastException e)
+                {
+                    Debug.WriteLine("Ignoring malformed registry entries that don't use an int: path=" + regKey + "." + valueName);
+                }
                 entriesToRemove.Remove(entry);
             }
 

--- a/wv2util/AppOverrideUi.xaml
+++ b/wv2util/AppOverrideUi.xaml
@@ -30,6 +30,8 @@
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
         <TabControl x:Name="TabControl" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+
+            <!-- App Override List -->
             <TabItem DataContext="{Binding Source={StaticResource AppOverrideList}}">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">
@@ -48,10 +50,11 @@
                     <Button x:Name="RemoveButton" IsEnabled="{Binding Path=IsValidSelection,Source={StaticResource AppOverrideListSelection}}" Content="Remove" HorizontalAlignment="Left" VerticalAlignment="Bottom" Width="75" Margin="257,0,0,5" RenderTransformOrigin="0.597,-3.701" Click="RemoveButton_Click"/>
 
                     <Label Content="Host app exe" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="337,17,0,0" Width="126" />
-                    <TextBox IsEnabled="{Binding Path=IsValidSelection,Source={StaticResource AppOverrideListSelection}}" IsReadOnly="{Binding Path=IsInvalidSelection,Source={StaticResource AppOverrideListSelection}}" ToolTip="E.g. 'example.exe'\nThe filename (not full path) of the executable of the desired host application." x:Name="AppOverrideHostAppTextBox" Text="{Binding Path=/HostApp, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" VerticalAlignment="Top" Margin="468,17,53,0" ScrollViewer.CanContentScroll="True" MaxLines="1" VerticalContentAlignment="Center" Height="26"/>
+                    <ComboBox x:Name="AppOverrideHostAppComboBox" IsEditable="true" ItemsSource="{Binding Source={StaticResource HostAppList}}" DisplayMemberPath="ExecutableName" TextSearch.TextPath="ExecutableName" ToolTip="E.g. 'example.exe'\nThe filename (not full path) of the executable of the desired host application." Text="{Binding Path=/HostApp, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top" Margin="468,17,53,0" ScrollViewer.CanContentScroll="True" VerticalContentAlignment="Center" Height="26" />
+                    <!--<TextBox IsEnabled="{Binding Path=IsValidSelection,Source={StaticResource AppOverrideListSelection}}" IsReadOnly="{Binding Path=IsInvalidSelection,Source={StaticResource AppOverrideListSelection}}" ToolTip="E.g. 'example.exe'\nThe filename (not full path) of the executable of the desired host application." x:Name="AppOverrideHostAppTextBox" Text="{Binding Path=/HostApp, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" VerticalAlignment="Top" Margin="468,17,53,0" ScrollViewer.CanContentScroll="True" MaxLines="1" VerticalContentAlignment="Center" Height="26"/>-->
 
                     <Label Content="Runtime path" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="337,48,0,0" Width="126"/>
-                    <TextBox IsEnabled="{Binding Path=IsValidSelection,Source={StaticResource AppOverrideListSelection}}" IsReadOnly="{Binding Path=IsInvalidSelection,Source={StaticResource AppOverrideListSelection}}" ToolTip="The full path of the WebView2 Runtime or non-stable browser. The path should contain msedgewebview2.exe." x:Name="AppOverrideRuntimePathTextBox" Text="{Binding Path=/RuntimePath, UpdateSourceTrigger=PropertyChanged}" Height="26" VerticalAlignment="Top" Margin="468,48,53,0" ScrollViewer.CanContentScroll="True" MaxLines="1" VerticalContentAlignment="Center"/>
+                    <ComboBox x:Name="AppOverrideRuntimePathComboBox" IsEditable="true" ItemsSource="{Binding Source={StaticResource RuntimeList}}" DisplayMemberPath="RuntimeLocation" TextSearch.TextPath="RuntimeLocation" ToolTip="The full path of the WebView2 Runtime or non-stable browser. The path should contain msedgewebview2.exe." Text="{Binding Path=/RuntimePath, UpdateSourceTrigger=PropertyChanged}" Height="26" VerticalAlignment="Top" Margin="468,48,53,0" VerticalContentAlignment="Center"/>
                     <Button IsEnabled="{Binding Path=IsValidSelection,Source={StaticResource AppOverrideListSelection}}" x:Name="AppOverrideRuntimePathButton" Content="..." HorizontalAlignment="Right" VerticalAlignment="Top" Width="37" Margin="0,52,10,0" Click="AppOverrideRuntimePathButton_Click"/>
 
                     <Label Content="User data path" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="337,79,0,0" Width="126"/>
@@ -65,6 +68,8 @@
                     <CheckBox IsEnabled="{Binding Path=IsValidSelection,Source={StaticResource AppOverrideListSelection}}" x:Name="AppOverrideReverseRuntimeSearchOrderCheckBox" IsChecked="{Binding Path=/ReverseSearchOrder, UpdateSourceTrigger=PropertyChanged}" Content="Reverse runtime search order" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="337,141,0,0" Height="16" Width="222"/>
                 </Grid>
             </TabItem>
+
+            <!-- Runtime list -->
             <TabItem DataContext="{Binding Source={StaticResource RuntimeList}}">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">
@@ -88,6 +93,8 @@
                     </ListView.View>
                 </ListView>
             </TabItem>
+
+            <!-- Host App list -->
             <TabItem DataContext="{Binding Source={StaticResource HostAppList}}">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">

--- a/wv2util/AppOverrideUi.xaml.cs
+++ b/wv2util/AppOverrideUi.xaml.cs
@@ -141,7 +141,8 @@ namespace wv2util
             folderBrowserDialog.Description = "Select a WebView2 Runtime folder";
             if (folderBrowserDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
-                this.AppOverrideRuntimePathTextBox.Text = folderBrowserDialog.SelectedPath;
+                //this.AppOverrideRuntimePathTextBox.Text = folderBrowserDialog.SelectedPath;
+                this.AppOverrideRuntimePathComboBox.Text = folderBrowserDialog.SelectedPath;
             }
         }
 

--- a/wv2util/RuntimeList.cs
+++ b/wv2util/RuntimeList.cs
@@ -56,6 +56,10 @@ namespace wv2util
                 {
                     return "Stable";
                 }
+                else if (ExePath.ToLower().Contains("\\edgewebview\\"))
+                {
+                    return "Stable WebView2 Runtime";
+                }
                 else
                 {
                     return "Unknown";
@@ -170,7 +174,10 @@ namespace wv2util
 
                         foreach (string path in foundExes)
                         {
-                            yield return new RuntimeEntry(path);
+                            if (!path.ToLower().Contains(@"edge\application") && !path.ToLower().Contains("edgecore"))
+                            {
+                                yield return new RuntimeEntry(path);
+                            }
                         }
                     }
                 }

--- a/wv2util/SortUtil.cs
+++ b/wv2util/SortUtil.cs
@@ -75,7 +75,7 @@ namespace wv2util
 
         public static int CompareChannelStrings(string left, string right)
         {
-            string[] channels = { "Canary", "Dev", "Beta", "Stable" };
+            string[] channels = { "Canary", "Dev", "Beta", "Stable", "Stable WebView2 Runtime" };
             int leftPos = Array.IndexOf(channels, left);
             int rightPos = Array.IndexOf(channels, right);
             return leftPos - rightPos;


### PR DESCRIPTION
Remove 'EdgeCore' and 'Stable' from runtime list; Update channel to include 'WebView2 Runtime'; Fix cast crash from malformed registry; Make override exe name and runtime comboboxes populated from the runtime list and host app list.