### PR TITLE
New override UI, fix bad bugs, warnings are errors

### DIFF
--- a/wv2util/App.xaml.cs
+++ b/wv2util/App.xaml.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Configuration;
-using System.Data;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Security.Principal;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace wv2util

--- a/wv2util/App.xaml.cs
+++ b/wv2util/App.xaml.cs
@@ -17,11 +17,13 @@ namespace wv2util
             // So we check at runtime and rerun ourselves as admin.
             if (!IsRunAsAdministrator())
             {
-                var processInfo = new ProcessStartInfo(Assembly.GetExecutingAssembly().CodeBase);
+                ProcessStartInfo processInfo = new ProcessStartInfo(Assembly.GetExecutingAssembly().CodeBase)
+                {
 
-                // The following properties run the new process as administrator
-                processInfo.UseShellExecute = true;
-                processInfo.Verb = "runas";
+                    // The following properties run the new process as administrator
+                    UseShellExecute = true,
+                    Verb = "runas"
+                };
 
                 // Start the new process
                 try
@@ -40,8 +42,8 @@ namespace wv2util
         }
         private bool IsRunAsAdministrator()
         {
-            var wi = WindowsIdentity.GetCurrent();
-            var wp = new WindowsPrincipal(wi);
+            WindowsIdentity wi = WindowsIdentity.GetCurrent();
+            WindowsPrincipal wp = new WindowsPrincipal(wi);
 
             return wp.IsInRole(WindowsBuiltInRole.Administrator);
         }

--- a/wv2util/AppOverride.cs
+++ b/wv2util/AppOverride.cs
@@ -152,6 +152,11 @@ namespace wv2util
             RegistryKey regKey;
             string[] valueNames;
 
+            // We want to minimally change collection to make it match the registry
+            // We start by assuming everything in the collection is no longer in the
+            // registry. We add every entry to entriesToRemove. Later we go through
+            // the registry and remove reg entries from the entriesToRemove since
+            // they still exist.
             foreach (AppOverrideEntry entry in collection)
             {
                 entriesToRemove.Add(entry);
@@ -164,7 +169,6 @@ namespace wv2util
             {
                 AppOverrideEntry entry = GetOrCreateEntry(appNameToEntry, collection, valueName);
                 entry.RuntimePath = (string)regKey.GetValue(valueName);
-                entry.InitializationComplete();
                 entriesToRemove.Remove(entry);
             }
 
@@ -183,7 +187,6 @@ namespace wv2util
                 {
                     Debug.WriteLine("Ignoring malformed registry entries that don't use an int: path=" + regKey + "." + valueName);
                 }
-                entry.InitializationComplete();
                 entriesToRemove.Remove(entry);
             }
 
@@ -193,7 +196,6 @@ namespace wv2util
             {
                 AppOverrideEntry entry = GetOrCreateEntry(appNameToEntry, collection, valueName);
                 entry.BrowserArguments = (string)regKey.GetValue(valueName);
-                entry.InitializationComplete();
                 entriesToRemove.Remove(entry);
             }
 
@@ -203,7 +205,6 @@ namespace wv2util
             {
                 AppOverrideEntry entry = GetOrCreateEntry(appNameToEntry, collection, valueName);
                 entry.UserDataPath = (string)regKey.GetValue(valueName);
-                entry.InitializationComplete();
                 entriesToRemove.Remove(entry);
             }
 
@@ -228,8 +229,15 @@ namespace wv2util
                 {
                     HostApp = "*"
                 };
-                entry.InitializationComplete();
                 collection.Insert(0, entry);
+            }
+
+            // We may have created entries above when going through the registry.
+            // Different reg entries can apply to the same AppOverrideEntry so we
+            // wait till the end to mark it initialized.
+            foreach (AppOverrideEntry entry in collection)
+            {
+                entry.InitializationComplete();
             }
         }
 

--- a/wv2util/AppOverride.cs
+++ b/wv2util/AppOverride.cs
@@ -6,8 +6,6 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace wv2util
 {
@@ -275,8 +273,8 @@ namespace wv2util
                 // recording the entry. An empty string browser arguments is fine because its merged with normal command line arguments
                 // and won't change anything, unlike the paths.
                 OpenRegistryPath(Registry.CurrentUser, s_registryPathAdditionalBrowserArguments, true)?.SetValue(
-                    entry.HostApp, 
-                    entry.BrowserArguments != null ? entry.BrowserArguments : "", 
+                    entry.HostApp,
+                    entry.BrowserArguments != null ? entry.BrowserArguments : "",
                     RegistryValueKind.String);
 
                 if (entry.RuntimePath != null && entry.RuntimePath != "")

--- a/wv2util/AppOverrideUi.xaml.cs
+++ b/wv2util/AppOverrideUi.xaml.cs
@@ -14,7 +14,7 @@ namespace wv2util
     {
         public System.Windows.Controls.ListBox ListBox
         {
-            get { return m_ListBox; }
+            get => m_ListBox;
 
             set
             {
@@ -60,15 +60,15 @@ namespace wv2util
         private System.Windows.Controls.ListBox m_ListBox = null;
         private AppOverrideEntry m_Entry = null;
 
-        public bool IsInvalidSelection { get { return !IsValidSelection; } }
-        public bool IsValidSelection { get { return ListBox != null && ListBox.SelectedIndex != -1; } }
+        public bool IsInvalidSelection => !IsValidSelection;
+        public bool IsValidSelection => ListBox != null && ListBox.SelectedIndex != -1;
         public bool IsValidAndFixedVersionSelection
         {
             get
             {
                 if (IsValidSelection)
                 {
-                    var entry = (AppOverrideEntry)ListBox.Items[ListBox.SelectedIndex];
+                    AppOverrideEntry entry = (AppOverrideEntry)ListBox.Items[ListBox.SelectedIndex];
                     return entry.IsRuntimeFixedVersion;
                 }
                 return false;
@@ -102,16 +102,18 @@ namespace wv2util
 
         private void AddNewButton_Click(object sender, RoutedEventArgs e)
         {
-            AppOverrideEntry entry = new AppOverrideEntry();
-            entry.HostApp = "New " + (++m_NewEntriesCount);
+            AppOverrideEntry entry = new AppOverrideEntry
+            {
+                HostApp = "New " + (++m_NewEntriesCount)
+            };
             AppOverrideListData.Add(entry);
         }
 
-        protected AppOverrideList AppOverrideListData { get { return (AppOverrideList)AppOverrideListBox?.ItemsSource; } }
+        protected AppOverrideList AppOverrideListData => (AppOverrideList)AppOverrideListBox?.ItemsSource;
         private uint m_NewEntriesCount = 0;
 
-        protected RuntimeList RuntimeListData { get { return (RuntimeList)RuntimeList?.ItemsSource; } }
-        protected HostAppList HostAppsListData { get { return (HostAppList)HostAppListView?.ItemsSource; } }
+        protected RuntimeList RuntimeListData => (RuntimeList)RuntimeList?.ItemsSource;
+        protected HostAppList HostAppsListData => (HostAppList)HostAppListView?.ItemsSource;
 
         private void Reload_Click(object sender, RoutedEventArgs e)
         {
@@ -158,21 +160,25 @@ namespace wv2util
 
         private void AppOverrideRuntimePathButton_Click(object sender, RoutedEventArgs e)
         {
-            var folderBrowserDialog = new FolderBrowserDialog();
-            folderBrowserDialog.Description = "Select a WebView2 Runtime folder";
+            FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog
+            {
+                Description = "Select a WebView2 Runtime folder"
+            };
             if (folderBrowserDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
-                this.AppOverrideRuntimePathComboBox.Text = folderBrowserDialog.SelectedPath;
+                AppOverrideRuntimePathComboBox.Text = folderBrowserDialog.SelectedPath;
             }
         }
 
         private void AppOverrideUserDataPathButton_Click(object sender, RoutedEventArgs e)
         {
-            var folderBrowserDialog = new FolderBrowserDialog();
-            folderBrowserDialog.Description = "Select the path to a user data folder";
+            FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog
+            {
+                Description = "Select the path to a user data folder"
+            };
             if (folderBrowserDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
-                this.AppOverrideUserDataPathTextBox.Text = folderBrowserDialog.SelectedPath;
+                AppOverrideUserDataPathTextBox.Text = folderBrowserDialog.SelectedPath;
             }
         }
 
@@ -183,7 +189,7 @@ namespace wv2util
 
         private async void RuntimesReload_Click(object sender, RoutedEventArgs e)
         {
-            var originalContent = RuntimesReload.Content;
+            object originalContent = RuntimesReload.Content;
             RuntimesReload.Content = "⌚";
             RuntimesReload.IsEnabled = false;
 
@@ -195,7 +201,7 @@ namespace wv2util
 
         private async void HostAppsReload_Click(object sender, RoutedEventArgs e)
         {
-            var originalContent = HostAppsReload.Content;
+            object originalContent = HostAppsReload.Content;
             HostAppsReload.Content = "⌚";
             HostAppsReload.IsEnabled = false;
 
@@ -231,7 +237,7 @@ namespace wv2util
 
         }
 
-        private SortUtil.SortColumnContext m_runtimeSortColumn = new SortUtil.SortColumnContext();
+        private readonly SortUtil.SortColumnContext m_runtimeSortColumn = new SortUtil.SortColumnContext();
         private void GridViewColumnHeader_Runtime_Path_Click(object sender, RoutedEventArgs e)
         {
             m_runtimeSortColumn.SelectColumn(0);
@@ -254,7 +260,7 @@ namespace wv2util
                 m_runtimeSortColumn.SortDirection * SortUtil.CompareChannelStrings(left.Channel, right.Channel));
         }
 
-        private SortUtil.SortColumnContext m_hostAppSortColumn = new SortUtil.SortColumnContext();
+        private readonly SortUtil.SortColumnContext m_hostAppSortColumn = new SortUtil.SortColumnContext();
         private void GridViewColumnHeader_HostApps_Executable_Click(object sender, RoutedEventArgs e)
         {
             m_hostAppSortColumn.SelectColumn(0);
@@ -310,7 +316,7 @@ namespace wv2util
             bool mutable = false;
             if (selectedIndex >= 0 && selectedIndex < AppOverrideListData.Count)
             {
-                AppOverrideEntry selectedEntry = (AppOverrideEntry)AppOverrideListData[selectedIndex];
+                AppOverrideEntry selectedEntry = AppOverrideListData[selectedIndex];
                 mutable = selectedEntry.Mutable;
             }
 

--- a/wv2util/AppOverrideUi.xaml.cs
+++ b/wv2util/AppOverrideUi.xaml.cs
@@ -106,6 +106,7 @@ namespace wv2util
             {
                 HostApp = "New " + (++m_NewEntriesCount)
             };
+            entry.InitializationComplete();
             AppOverrideListData.Add(entry);
         }
 

--- a/wv2util/AppOverrideUi.xaml.cs
+++ b/wv2util/AppOverrideUi.xaml.cs
@@ -1,22 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Forms;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
-using System.Windows.Shapes;
 using Clipboard = System.Windows.Clipboard;
 
 namespace wv2util
@@ -136,8 +125,8 @@ namespace wv2util
                 RuntimeEntry selection = (RuntimeEntry)RuntimeList.SelectedItem;
                 try
                 {
-                    Clipboard.SetText(selection.RuntimeLocation + "\t" + 
-                        selection.Version + "\t" + 
+                    Clipboard.SetText(selection.RuntimeLocation + "\t" +
+                        selection.Version + "\t" +
                         selection.Channel);
                 }
                 catch (System.Runtime.InteropServices.COMException)
@@ -153,8 +142,8 @@ namespace wv2util
                 HostAppEntry selection = (HostAppEntry)HostAppListView.SelectedItem;
                 try
                 {
-                    Clipboard.SetText(selection.ExecutableName + "\t" + 
-                        selection.Runtime.RuntimeLocation + "\t" + 
+                    Clipboard.SetText(selection.ExecutableName + "\t" +
+                        selection.Runtime.RuntimeLocation + "\t" +
                         selection.Runtime.Version + "\t" +
                         selection.Runtime.Channel + "\t" +
                         selection.UserDataPath + "\t" +
@@ -165,7 +154,7 @@ namespace wv2util
                     // We might fail to open clipboard. Just ignore
                 }
             }
-        }       
+        }
 
         private void AppOverrideRuntimePathButton_Click(object sender, RoutedEventArgs e)
         {
@@ -199,7 +188,7 @@ namespace wv2util
             RuntimesReload.IsEnabled = false;
 
             await RuntimeListData.FromDiskAsync();
-            
+
             RuntimesReload.Content = originalContent;
             RuntimesReload.IsEnabled = true;
         }
@@ -225,7 +214,7 @@ namespace wv2util
 
         private void RuntimeListMouseRightButtonUp(object sender, MouseButtonEventArgs e)
         {
-            
+
         }
 
         private void MenuItemCopyRow(object sender, RoutedEventArgs e)

--- a/wv2util/HostAppList.cs
+++ b/wv2util/HostAppList.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Management;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace wv2util
@@ -24,7 +23,7 @@ namespace wv2util
             this.PID = pid;
         }
         public string ExecutableName
-        { 
+        {
             get
             {
                 return ExecutablePath.Split(new char[] { '\\', '/' }).ToList<string>().Last<string>();
@@ -162,7 +161,7 @@ namespace wv2util
                     string commandLinePartTrimmed = commandLinePart.Trim().Replace("\\\"", "\"").Trim('"');
                     if (commandLinePartTrimmed.StartsWith("--type"))
                     {
-                        processType = commandLinePartTrimmed.Split('=')[1].Trim(new char[] { '"', ' '});
+                        processType = commandLinePartTrimmed.Split('=')[1].Trim(new char[] { '"', ' ' });
                     }
 
                     if (commandLinePartTrimmed.StartsWith("--user-data-dir"))
@@ -212,7 +211,7 @@ namespace wv2util
         }
         public static IReadOnlyDictionary<uint, string> PidToClientDllPath { get => s_snapShot.PidToClientDllPath; }
     }
-     
+
     public class ProcessSnapshot
     {
         private static readonly uint TH32CS_SNAPPROCESS = 0x2;
@@ -239,11 +238,9 @@ namespace wv2util
             m_ChildPidToParentPid = new Dictionary<uint, uint>();
             PidToClientDllPath = new Dictionary<uint, string>();
 
-            PROCESSENTRY32 procInfo = new PROCESSENTRY32();
-            procInfo.dwSize = (uint)Marshal.SizeOf(typeof(PROCESSENTRY32));
+            PROCESSENTRY32 procInfo = new PROCESSENTRY32() { dwSize = (uint)Marshal.SizeOf(typeof(PROCESSENTRY32)) };
 
             MODULEENTRY32 modEntry = new MODULEENTRY32() { dwSize = (uint)Marshal.SizeOf(typeof(MODULEENTRY32)) };
-            modEntry.dwSize = (uint)Marshal.SizeOf(typeof(MODULEENTRY32));
 
             if (Process32First(m_hSnapshot, ref procInfo))
             {

--- a/wv2util/Properties/AssemblyInfo.cs
+++ b/wv2util/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/wv2util/RuntimeList.cs
+++ b/wv2util/RuntimeList.cs
@@ -18,7 +18,7 @@ namespace wv2util
             ExePath = location;
         }
         public string ExePath { get; protected set; }
-        public string RuntimeLocation { get { return Directory.GetParent(ExePath).FullName; } }
+        public string RuntimeLocation => Directory.GetParent(ExePath).FullName;
         public string Version
         {
             get
@@ -106,33 +106,33 @@ namespace wv2util
             // Only update the entries on the caller thread to ensure the
             // caller isn't trying to enumerate the entries while
             // we're updating them.
-            this.SetEntries(newEntries);
+            SetEntries(newEntries);
         }
 
         protected void SetEntries(IEnumerable<RuntimeEntry> newEntries)
         {
             // Use ToList to get a fixed collection that won't get angry that we're calling
             // Add and Remove on it while enumerating.
-            foreach (var entry in this.Except(newEntries).ToList<RuntimeEntry>())
+            foreach (RuntimeEntry entry in this.Except(newEntries).ToList<RuntimeEntry>())
             {
-                this.Items.Remove(entry);
+                Items.Remove(entry);
             }
-            foreach (var entry in newEntries.Except(this).ToList<RuntimeEntry>())
+            foreach (RuntimeEntry entry in newEntries.Except(this).ToList<RuntimeEntry>())
             {
-                this.Items.Add(entry);
+                Items.Add(entry);
             }
 
-            this.OnPropertyChanged(new PropertyChangedEventArgs("Count"));
-            this.OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
-            this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            OnPropertyChanged(new PropertyChangedEventArgs("Count"));
+            OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         public void Sort<T>(Comparison<T> comparison)
         {
-            ArrayList.Adapter((IList)this.Items).Sort(new wv2util.SortUtil.ComparisonComparer<T>(comparison));
+            ArrayList.Adapter((IList)Items).Sort(new wv2util.SortUtil.ComparisonComparer<T>(comparison));
 
-            this.OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
-            this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         private static List<RuntimeEntry> GetLocalRepoRuntimesInRoot(DirectoryInfo root)
@@ -140,7 +140,7 @@ namespace wv2util
             List<RuntimeEntry> runtimes = new List<RuntimeEntry>();
             try
             {
-                foreach (var subDirectory in root.GetDirectories())
+                foreach (DirectoryInfo subDirectory in root.GetDirectories())
                 {
                     try
                     {
@@ -152,7 +152,7 @@ namespace wv2util
                                 DirectoryInfo outDirectory = srcDirectory.GetDirectories("out").FirstOrDefault();
                                 if (outDirectory != null)
                                 {
-                                    foreach (var buildDirectory in outDirectory.GetDirectories("release_*"))
+                                    foreach (DirectoryInfo buildDirectory in outDirectory.GetDirectories("release_*"))
                                     {
                                         try
                                         {
@@ -179,12 +179,12 @@ namespace wv2util
         private static IEnumerable<RuntimeEntry> GetLocalRepoRuntimes()
         {
             IEnumerable<RuntimeEntry> runtimes = new List<RuntimeEntry>();
-            foreach (var driveInfo in DriveInfo.GetDrives().Where(
+            foreach (DriveInfo driveInfo in DriveInfo.GetDrives().Where(
                 drive => drive.IsReady && // Try to skip CDs or other removable media that's not ready
                 drive.TotalSize > 1073741824)) // Skip disks too small to contain local repos
             {
                 runtimes = runtimes.Concat(GetLocalRepoRuntimesInRoot(driveInfo.RootDirectory));
-                foreach (var rootFolder in driveInfo.RootDirectory.GetDirectories())
+                foreach (DirectoryInfo rootFolder in driveInfo.RootDirectory.GetDirectories())
                 {
                     try
                     {
@@ -208,7 +208,7 @@ namespace wv2util
 
             if (downloadFolder != null)
             {
-                foreach (var subFolder in downloadFolder.GetDirectories())
+                foreach (DirectoryInfo subFolder in downloadFolder.GetDirectories())
                 {
                     FileInfo exeFile = subFolder.GetFiles("msedgewebview2.exe").FirstOrDefault();
                     if (exeFile != null)

--- a/wv2util/RuntimeList.cs
+++ b/wv2util/RuntimeList.cs
@@ -7,9 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Controls;
 
 namespace wv2util
 {
@@ -128,7 +126,7 @@ namespace wv2util
             this.OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
             this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
-     
+
         public void Sort<T>(Comparison<T> comparison)
         {
             ArrayList.Adapter((IList)this.Items).Sort(new wv2util.SortUtil.ComparisonComparer<T>(comparison));

--- a/wv2util/SortUtil.cs
+++ b/wv2util/SortUtil.cs
@@ -2,8 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace wv2util
 {

--- a/wv2util/SortUtil.cs
+++ b/wv2util/SortUtil.cs
@@ -46,8 +46,8 @@ namespace wv2util
 
         public static int CompareVersionStrings(string left, string right)
         {
-            var leftParts = left.Split('.').Select(partAsString => int.Parse(partAsString));
-            var rightParts = right.Split('.').Select(partAsString => int.Parse(partAsString));
+            IEnumerable<int> leftParts = left.Split('.').Select(partAsString => int.Parse(partAsString));
+            IEnumerable<int> rightParts = right.Split('.').Select(partAsString => int.Parse(partAsString));
 
             while (leftParts.Count() < rightParts.Count())
             {
@@ -58,8 +58,8 @@ namespace wv2util
                 rightParts.Append(0);
             }
 
-            var leftEnum = leftParts.GetEnumerator();
-            var rightEnum = rightParts.GetEnumerator();
+            IEnumerator<int> leftEnum = leftParts.GetEnumerator();
+            IEnumerator<int> rightEnum = rightParts.GetEnumerator();
             while (leftEnum.MoveNext() && rightEnum.MoveNext())
             {
                 int diff = leftEnum.Current - rightEnum.Current;

--- a/wv2util/wv2util.csproj
+++ b/wv2util/wv2util.csproj
@@ -42,8 +42,9 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>2</WarningLevel>
+    <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Update the override tab UI to be by scenario. Fix bugs in the override tab UI that could erase the registry entries when adding or removing entries to the list. Fix bugs in the Host Apps tab so that host app processes are actually displayed.

Warnings are now treated as errors and warning level is turned up to 4. All C# suggestions from VS have been applied.